### PR TITLE
fix: 🐛 friendRequest no longer hangs

### DIFF
--- a/src/screens/friends/FriendRequestFeedView.tsx
+++ b/src/screens/friends/FriendRequestFeedView.tsx
@@ -45,7 +45,6 @@ export const FriendRequestFeed = () => {
 		response: string,
 	) => {
 		respondToFriendRequest({ userID, friendID, response });
-		fetchFriends();
 	};
 
 	useEffect(() => {


### PR DESCRIPTION
in requestHandler, it was fetching friends again causing a bug in android